### PR TITLE
pause-spotify: Don't launch Spotify if not running

### DIFF
--- a/triggers/pause-spotify/call-connected
+++ b/triggers/pause-spotify/call-connected
@@ -1,3 +1,3 @@
 #!/usr/bin/env osascript
 
-tell application "Spotify" to pause
+if application "Spotify" is running then tell application "Spotify" to pause


### PR DESCRIPTION
You can verify with

``` bash
osascript -e 'tell application "Spotify" to pause'
```

that the old version of the command will launch Spotify if not already running.