### PR TITLE
pause-music: Don't launch Music.app if not running

### DIFF
--- a/triggers/pause-music/call-connected
+++ b/triggers/pause-music/call-connected
@@ -1,3 +1,3 @@
 #!/usr/bin/env osascript
 
-tell application "Music" to pause
+if application "Music" is running then tell application "Music" to pause


### PR DESCRIPTION
You can verify with

``` bash
osascript -e 'tell application "Music" to pause'

```
that the old version of the command will launch Music.app if not already running.