### PR TITLE
git-coauthors: fix syntax error

### DIFF
--- a/triggers/git-coauthors/participant-joined
+++ b/triggers/git-coauthors/participant-joined
@@ -5,7 +5,7 @@ name = ENV.fetch("TUPLE_TRIGGER_FULL_NAME")
 template_path = "#{Dir.home}/.gitmessage"
 line = "Co-Authored-By: #{name} <#{email}>"
 
-exists = File.exists?(template_path)
+exists = File.exist?(template_path)
 
 if exists && File.read(template_path).include?(line)
   exit 0

--- a/triggers/git-coauthors/participant-left
+++ b/triggers/git-coauthors/participant-left
@@ -4,7 +4,7 @@ email = ENV.fetch("TUPLE_TRIGGER_EMAIL")
 name = ENV.fetch("TUPLE_TRIGGER_FULL_NAME")
 template_path = "#{Dir.home}/.gitmessage"
 
-if !File.exists?(template_path)
+if !File.exist?(template_path)
   exit 0
 end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When running the trigger on an environment configured with the latest version of Ruby you would get a syntax error with an exit code 1.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We are not sure which version will be installed on the user's machine, so maybe we should err on the side of using the syntax from the latest version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I validated this locally and tested with some pairing sessions, seems to work fine for my case

## Additional Context

I am running all this inside MacOS, with my personal environment configured to have latest version of ruby as global default (using `asdf` to manage).
