### PR TITLE
Bump `actions/upload-artifact` to fix CI & configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/util"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/pull-request-validator.yml
+++ b/.github/workflows/pull-request-validator.yml
@@ -23,7 +23,7 @@ jobs:
           script: |
             const validate = require("./util/pull-request-validator.js");
             await validate({ github, context, core });
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: validation-results.json


### PR DESCRIPTION
`actions/upload-artifact@v3` is deprecated and no longer works, failing CI.

This bumps us to `v4`, and configures Dependabot so this doesn't fall through the cracks in the future.2