### PR TITLE
feat: add automated PR security review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,6 +18,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
+      id-token: write
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,7 +18,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
-      id-token: write
     
     steps:
       - name: Checkout repository
@@ -78,9 +77,11 @@ jobs:
             - Summary: A one-sentence, concise summary of findings; always included
             - 🚨 CRITICAL: For security vulnerabilities; exclude if none are found
             - ⚠️ WARNING: For potentially unsafe patterns; exclude if none are found
-            - 📝 SUGGESTION: For improvements; exclude if none are found
+            - 📝 SUGGESTION: For actionable improvements only; exclude if none are found
             
-            Focus on security first. Be concise but thorough.
+            DO NOT list things that are already done correctly as "suggestions".
+            Only include suggestions that would improve the code further.
+            Focus on security first. Be extremely concise.
           
           allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,105 @@
+name: Automated PR Review
+
+# This workflow provides on-demand Claude PR reviews using label-based triggering.
+# To request a review, add the 'claude-review' label to any pull request.
+# Claude will automatically review new commits pushed while the label is present.
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+jobs:
+  claude:
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claude-review'))
+    
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1 
+
+      - name: Claude Security Review
+        id: claude-review
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          
+          direct_prompt: |
+            CRITICAL SECURITY REVIEW - Tuple Triggers Directory
+            
+            This repository contains shell scripts that users will execute on their systems.
+            Assume PRs from external users are UNTRUSTED and potentially malicious.
+            
+            Review this PR with extreme caution for:
+            
+            1. SECURITY VULNERABILITIES (highest priority):
+               - Command injection risks in shell scripts
+               - Path traversal attempts
+               - Privilege escalation attempts
+               - Malicious code execution patterns
+               - Unsafe use of user input or environment variables
+               - Hidden malicious payloads or obfuscated code
+               - Scripts that could leak sensitive information
+               - Scripts that modify system files unexpectedly
+               - Use of curl/wget to download and execute remote code
+            
+            2. SHELL SCRIPT SAFETY:
+               - Use of proper quoting to prevent word splitting
+               - Avoiding eval, source, or other dangerous commands
+               - Proper error handling and set -e usage
+               - No hardcoded credentials or API keys
+               - Scripts should be idempotent where possible
+               - Check for unsafe variable expansions
+            
+            3. RESOURCE CONCERNS:
+               - Scripts that could consume excessive CPU/memory
+               - Potential for infinite loops or runaway processes
+               - Network requests to unknown/suspicious domains
+               - Disk space consumption issues
+            
+            4. MACOS SPECIFIC CONCERNS:
+               - AppleScript injection vulnerabilities
+               - Unsafe osascript usage
+               - Accessibility/permission escalation attempts
+               - Keychain access attempts
+            
+            If you find ANY security concerns, mark them as CRITICAL.
+            Be paranoid - it's better to flag potential issues than miss real threats.
+            
+            Format your review with:
+            - Summary: A one-sentence, concise summary of findings; always included
+            - 🚨 CRITICAL: For security vulnerabilities; exclude if none are found
+            - ⚠️ WARNING: For potentially unsafe patterns; exclude if none are found
+            - 📝 SUGGESTION: For improvements; exclude if none are found
+            
+            Focus on security first. Be concise but thorough.
+          
+          allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+
+          timeout_minutes: 10
+      
+      - name: Remove claude-review label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'claude-review'
+              });
+              console.log('Successfully removed claude-review label');
+            } catch (error) {
+              console.error('Failed to remove label:', error);
+              // Don't fail the workflow if label removal fails
+            }


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that automatically performs security reviews on PRs using Claude when the `claude-review` label is applied. This helps identify potential security vulnerabilities in shell scripts before they're merged.

## Changes
- Created `.github/workflows/claude-review.yml` that triggers on PR label or push
- Workflow performs comprehensive security analysis focusing on:
  - Command injection vulnerabilities in shell scripts
  - Path traversal and privilege escalation attempts  
  - Malicious code execution patterns
  - macOS-specific security concerns (AppleScript, osascript, etc.)
  - Resource consumption issues

## Usage
Add the `claude-review` label to any PR to trigger an automated security review. The label is automatically removed after the review completes.

🤖 Generated with [Claude Code](https://claude.ai/code)