### PR TITLE
Fix PR author attribution in thank you comments

### DIFF
--- a/util/pull-request-commenter.js
+++ b/util/pull-request-commenter.js
@@ -38,7 +38,7 @@ async function upsertComment({ github, context, body, number }) {
 }
 
 module.exports = async function pullRequestCommenter({ github, context }) {
-  const { number, results } = JSON.parse(
+  const { number, author, results } = JSON.parse(
     fs.readFileSync("validation-results.json")
   );
 
@@ -47,6 +47,7 @@ module.exports = async function pullRequestCommenter({ github, context }) {
     context,
     body: renderTemplate("pull-request-comment", {
       context,
+      author,
       results,
     }),
     number,

--- a/util/pull-request-validator.js
+++ b/util/pull-request-validator.js
@@ -16,7 +16,11 @@ module.exports = async function validatePullRequest({ github, context, core }) {
   }));
 
   const output = JSON.stringify(
-    { number: context.issue.number, results: validationResults },
+    { 
+      number: context.issue.number, 
+      author: context.payload.pull_request.user.login,
+      results: validationResults 
+    },
     null,
     2
   );

--- a/util/templates/pull-request-comment.ejs
+++ b/util/templates/pull-request-comment.ejs
@@ -1,4 +1,4 @@
-Thanks for your contribution, @<%= context.payload.sender.login %>! :tada:
+Thanks for your contribution, @<%= author %>! :tada:
 
 <% if (results.length === 1) { %>
   We've done some automated sense checks on your trigger, `<%= results[0].trigger %>`. <% if (results[0].success) { -%>All looks great! Someone from Tuple will now manually review your trigger's code and get back to you.<%_ } else { -%>It seems there might be some more work to do:<%_ } -%>


### PR DESCRIPTION
## Summary
- Fixed incorrect user attribution in automated PR comments
- Now thanks the actual PR author instead of the person who merged

## Problem
The GitHub Action was using `context.payload.sender.login` which refers to whoever triggered the workflow (the merger), not the PR author. This meant merge commits were incorrectly attributing thanks to the merger instead of the contributor.

## Solution
- Modified `pull-request-validator.js` to capture and save the PR author's login
- Updated `pull-request-commenter.js` to read and pass the author information
- Changed the template to use the correct author variable

## Test plan
- [ ] Create a test PR with trigger changes
- [ ] Have a different user merge the PR
- [ ] Verify the automated comment thanks the PR author, not the merger

🤖 Generated with [Claude Code](https://claude.ai/code)