### PR TITLE
Fix Claude review workflow authentication for fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,7 +18,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: read
-      id-token: write
     
     steps:
       - name: Checkout repository
@@ -31,6 +30,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           
           direct_prompt: |
             CRITICAL SECURITY REVIEW - Tuple Triggers Directory


### PR DESCRIPTION
## Summary
- Fixes authentication errors when claude-review workflow runs on PRs from forks
- The action was trying to use OIDC tokens which aren't available for external contributors

## Changes
- Add explicit `github_token: ${{ secrets.GITHUB_TOKEN }}` parameter to claude-code-action
- Remove `id-token: write` permission since it's no longer needed

## Context
The claude-code-action needs a GitHub token for PR operations (posting comments, etc.). When not explicitly provided, it attempts to use OIDC to obtain a more powerful token. However, GitHub restricts OIDC tokens on PRs from forks for security reasons, causing the workflow to fail.

By explicitly providing the standard GITHUB_TOKEN, we avoid the OIDC token request entirely and the workflow should work on all PRs.

Fixes the error: "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable"