### PR TITLE
ci: skip GitHub Actions for dependabot PRs

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -10,6 +10,7 @@ jobs:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pull-request-validator.yml
+++ b/.github/workflows/pull-request-validator.yml
@@ -8,6 +8,7 @@ jobs:
   pull-request-validator:
     name: Validator
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Skip Claude PR review workflow for dependabot PRs to avoid unnecessary runs
- Skip pull request validator workflow for dependabot PRs to reduce CI overhead

## Changes

- Added `if: github.actor != 'dependabot[bot]'` condition to both workflows:
  - `.github/workflows/claude-pr-review.yml`
  - `.github/workflows/pull-request-validator.yml`

This prevents these workflows from running on dependabot-created PRs, reducing CI resource usage while maintaining full validation for human-created PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)