### PR TITLE
ci: group dependabot updates and upgrade dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
     directory: "/util"
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,6 +41,6 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v0.0.55
+        uses: anthropics/claude-code-action@v1.0.3
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/util/package.json
+++ b/util/package.json
@@ -6,6 +6,6 @@
     "@aws-sdk/client-dynamodb": "^3.879.0",
     "@aws-sdk/lib-dynamodb": "^3.862.0",
     "ejs": "^3.1.10",
-    "zod": "^4.0.17"
+    "zod": "^4.1.5"
   }
 }

--- a/util/pnpm-lock.yaml
+++ b/util/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.1.10
         version: 3.1.10
       zod:
-        specifier: ^4.0.17
-        version: 4.0.17
+        specifier: ^4.1.5
+        version: 4.1.5
 
 packages:
 
@@ -399,8 +399,8 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
-  zod@4.0.17:
-    resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
+  zod@4.1.5:
+    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
 
 snapshots:
 
@@ -1172,4 +1172,4 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  zod@4.0.17: {}
+  zod@4.1.5: {}


### PR DESCRIPTION
## Summary
- Configure Dependabot to group minor and patch updates together to reduce PR noise
- Update claude-code-action from v0.0.55 to v1.0.3
- Update zod dependency from 4.0.17 to 4.1.5

## Changes
- Added grouped update configuration in `.github/dependabot.yml` for minor and patch dependencies
- Updated GitHub Actions workflow to use latest claude-code-action version
- Merged and updated utility dependencies via Dependabot

🤖 Generated with [Claude Code](https://claude.ai/code)