### PR TITLE
Add call-recording-started trigger type

### DIFF
--- a/util/support/config.js
+++ b/util/support/config.js
@@ -13,6 +13,7 @@ exports.AVAILABLE_TRIGGERS = [
   "webcam-share-ended",
   "participant-joined",
   "participant-left",
+  "call-recording-started",
   "call-recording-complete",
 ];
 exports.AVAILABLE_PLATFORMS = ["macos", "linux", "windows"];


### PR DESCRIPTION
## Summary
- Adds `call-recording-started` to the validator's available trigger types
- Fires when call recording begins, complementing the existing `call-recording-complete` trigger

## Test plan
- [ ] Verify PR validator still passes on existing triggers
- [ ] Confirm new trigger type is recognized by the linter

🤖 Generated with [Claude Code](https://claude.com/claude-code)