### PR TITLE
Auto-rebuild triggers-site on merge to main

### DIFF
--- a/.github/workflows/notify-site.yml
+++ b/.github/workflows/notify-site.yml
@@ -1,0 +1,12 @@
+name: Trigger triggers-site rebuild
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Poke Netlify build hook
+        run: curl -fsSL -X POST -d {} "${{ secrets.TRIGGERS_SITE_BUILD_HOOK }}"


### PR DESCRIPTION
## Summary

POSTs to a Netlify build hook (`TRIGGERS_SITE_BUILD_HOOK` secret) on every push to `main`, so a community-triggers merge fans out to a triggers-site rebuild without any manual step. End-to-end latency from merge to live: typically 1–2 minutes.

Implements step 3 of the one-time setup described in [tupleapp/triggers-site / docs/auto-deploy-on-community-merge.md](https://github.com/tupleapp/triggers-site/blob/main/docs/auto-deploy-on-community-merge.md). The corresponding `TRIGGERS_SITE_BUILD_HOOK` secret was added to this repo separately, so this workflow is functional the moment it merges.

## Why now

PR #87 (Claude Call Liaison) merged to `main` but did not appear on the live site, because this wiring didn't exist yet.