### PR TITLE
Drop hard-coded platform names from claude-call-liaison

### DIFF
--- a/triggers/claude-call-liaison/call-transcription-started
+++ b/triggers/claude-call-liaison/call-transcription-started
@@ -87,7 +87,7 @@ fi
 # during a long call). Cap at 100 lines each so we don't dump a 3-hour
 # history into the opening turn.
 {
-    printf 'Your user just started (or resumed) transcription on a Tuple pair-programming call. You are the proactive liaison: monitor for non-private dissemination opportunities and post them to Slack, Linear, or Notion per your system prompt. Privacy gates override everything. Follow the setup steps, then return silently and wait for a wake signal.\n\n'
+    printf 'Your user just started (or resumed) transcription on a Tuple pair-programming call. You are the proactive liaison: monitor for non-private dissemination opportunities and post them to the destinations in your appended context per your system prompt. Privacy gates override everything. Follow the setup steps, then return silently and wait for a wake signal.\n\n'
     printf '## Recent lifecycle events (last 100)\n\n```\n'
     tuple transcription events 2>/dev/null | tail -100 || printf '(no events yet)\n'
     printf '```\n\n## Recent transcript (last 100 lines)\n\n```\n'

--- a/triggers/claude-call-liaison/config.json
+++ b/triggers/claude-call-liaison/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Claude Call Liaison",
-  "description": "Launches a Claude Code session on every call that proactively posts non-private updates from the conversation to Slack, Linear, and Notion on your behalf. Hard privacy gates keep it silent on personnel, comp, legal, and named-customer or named-employee discussions.",
+  "description": "Launches a Claude Code session on every call that proactively posts non-private updates from the conversation to your team's chat, ticket tracker, and knowledge base on your behalf. Hard privacy gates keep it silent on personnel, comp, legal, and named-customer or named-employee discussions.",
   "platforms": ["macos"],
   "language": "bash"
 }


### PR DESCRIPTION
## Summary

Two leftover hard-codings of \"Slack, Linear, and Notion\" from before the trigger went tool-agnostic:

- **config.json description** — leaks through to the live API and the trigger directory listing on tuple.app/triggers.
- **call-transcription-started initial prompt** — first turn Claude sees on the call still named those three specifically, contradicting the system prompt which now thinks in destination categories.

Both updated to use the same category-based language as the system prompt (\"team's chat, ticket tracker, and knowledge base\" / \"destinations in your appended context\").