### PR TITLE
chore: add dependency update age gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/util"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       minor-and-patch:
         patterns:

--- a/.github/workflows/pull-request-commenter.yml
+++ b/.github/workflows/pull-request-commenter.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 22
       - uses: pnpm/action-setup@v6
         with:
-          version: 8
+          version: 10.32.1
           run_install: |
             cwd: util
       - uses: actions/github-script@v8

--- a/.github/workflows/pull-request-validator.yml
+++ b/.github/workflows/pull-request-validator.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 22
       - uses: pnpm/action-setup@v6
         with:
-          version: 8
+          version: 10.32.1
           run_install: |
             cwd: util
       - uses: actions/github-script@v8

--- a/util/package.json
+++ b/util/package.json
@@ -2,6 +2,7 @@
   "name": "tuple-community-triggers-utils",
   "version": "0.0.1",
   "private": true,
+  "packageManager": "pnpm@10.32.1",
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.958.0",
     "@aws-sdk/lib-dynamodb": "^3.958.0",

--- a/util/pnpm-workspace.yaml
+++ b/util/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Adds a seven-day cooldown to Dependabot version update PRs and configures the pnpm utility project to reject package versions published within the last seven days. Pins pnpm to 10.32.1 in CI so the age gate is supported.

## Problem

Recent npm supply-chain attacks make same-day dependency adoption riskier. Waiting seven days gives compromised releases more time to be detected while leaving security update handling available.