### PR TITLE
fix: drop pi --name flag that older installs reject

### DIFF
--- a/triggers/open-in-pi/README.md
+++ b/triggers/open-in-pi/README.md
@@ -36,7 +36,7 @@ When `call-transcription-started` fires, Tuple provides `TUPLE_TRIGGER_CALL_ARTI
 2. Writes `pi-sidekick-prompt.md` into that directory.
 3. Writes an executable `launch-pi-sidekick.command` wrapper into that directory.
 4. Opens it in your preferred terminal via `open` (LaunchServices). With `PREFERRED_TERM` empty it opens in your default handler for `.command` files; set it to one of `ghostty | iterm | alacritty | terminal` to force one. No AppleScript, so it triggers no macOS accessibility prompt.
-5. The wrapper starts a login-interactive zsh, changes into the transcription directory, and runs `pi --name "Tuple Pi Sidekick" "$(cat pi-sidekick-prompt.md)"`. Pi auto-discovers `.pi/extensions/*.ts` from that directory, so the watcher is active immediately.
+5. The wrapper starts a login-interactive zsh, changes into the transcription directory, and runs `pi "$(cat pi-sidekick-prompt.md)"`. Pi auto-discovers `.pi/extensions/*.ts` from that directory, so the watcher is active immediately.
 
 The watcher (`tuple-call-watch.ts`) tails `transcriptions.jsonl` and `events.jsonl` (plus sibling directories for the same call) from saved byte offsets, resolves `user_id` to speaker names, and batches new lines on natural pauses (a ~3.5s lull, or every ~20s during continuous talking). It feeds a batch, and triggers a turn, only while Pi is idle and has no pending messages, so consumption never collides with your messages or with itself. It degrades safely: if its config is missing it watches the working directory, and any error is swallowed rather than taking down the session.
 

--- a/triggers/open-in-pi/call-transcription-started
+++ b/triggers/open-in-pi/call-transcription-started
@@ -129,7 +129,7 @@ if ! command -v pi >/dev/null 2>&1; then
     exit 127
 fi
 
-exec pi --name "Tuple Pi Sidekick" "$(cat "${PROMPT_FILE}")"
+exec pi "$(cat "${PROMPT_FILE}")"
 SCRIPT
 
 chmod 0755 "${LAUNCHER_FILE}"


### PR DESCRIPTION
## Problem

A customer's `open-in-pi` sidekick never started: the launcher ran `pi --name "Tuple Pi Sidekick"`, but `--name` only exists on newer `pi` builds, so their older `pi` rejected the flag and exited.

`--name` was added in 030869c to label terminal tabs. Newer local installs have it, which masked the break.

## Fix

Drop `--name` from the pi launcher. The launcher already emits a `\e]0;…\a` title escape, so the tab stays labelled "Tuple Pi Sidekick" without depending on the flag — exactly how the codex and opencode launchers work. Codex never passed `--name`, so nothing to change there.

Only the Claude triggers keep `--name`, where the Claude CLI supports it on every install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)