### PR TITLE
fix(triggers): Monitor-less live-follow fallback for Claude harnesses

### DIFF
--- a/triggers/call-summary-claude/tuple-call-watcher.py
+++ b/triggers/call-summary-claude/tuple-call-watcher.py
@@ -2,7 +2,7 @@
 """
 Tuple call companion watcher -- known-good, deterministic.
 
-Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [call-id] [transcripts-root]
+Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--max-wait SECS] [--offsets TAG] [call-id] [transcripts-root]
         (it's executable; equivalently `python3 tuple-call-watcher.py ...`)
   --catchup          one-shot: ignore any saved offset, read every file from the
                      start, print that backlog, save offsets, and exit. The
@@ -13,6 +13,12 @@ Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [c
                      either flag the watcher runs continuously (Claude + Monitor),
                      forwarding each poll's new records immediately and letting
                      Monitor re-wake the agent.
+  --max-wait SECS    only with --exit-on-batch: if no records arrive within SECS
+                     seconds, exit anyway with an empty batch, handing control
+                     back to the caller. Without it --exit-on-batch blocks until
+                     the next record -- which never comes in a silent room, so a
+                     poll-loop caller that does periodic work (e.g. a coach's
+                     silence checks) needs this to get a turn during silence.
   --offsets TAG      suffix for the per-session offset file
                      (.tuple-watcher-offsets-TAG), so two agents watching the same
                      call keep separate read positions.
@@ -38,6 +44,7 @@ import glob, os, sys, time
 exit_on_batch = False
 from_start = False
 offsets_tag = None
+max_wait = None
 positional = []
 _args = list(sys.argv[1:])
 _i = 0
@@ -54,6 +61,16 @@ while _i < len(_args):
             sys.stderr.write("tuple-watcher: --offsets needs a tag value\n")
             sys.exit(2)
         offsets_tag = _args[_i]
+    elif a == "--max-wait":
+        _i += 1
+        if _i >= len(_args) or _args[_i].startswith("--"):
+            sys.stderr.write("tuple-watcher: --max-wait needs a seconds value\n")
+            sys.exit(2)
+        try:
+            max_wait = float(_args[_i])
+        except ValueError:
+            sys.stderr.write("tuple-watcher: --max-wait needs a numeric seconds value\n")
+            sys.exit(2)
     else:
         positional.append(a)
     _i += 1
@@ -224,6 +241,12 @@ if from_start:
     sys.exit(0)
 
 
+# --max-wait deadline (only with --exit-on-batch): after this much wall-clock
+# with no flush, exit anyway so a poll-loop caller regains its turn during a
+# silent stretch. Reset on each flushed batch isn't needed -- exit-on-batch exits
+# on flush, so this loop only runs once per invocation.
+wait_deadline = (time.time() + max_wait) if (exit_on_batch and max_wait is not None) else None
+
 while True:
     newdata = collect()
 
@@ -247,6 +270,13 @@ while True:
         buf = []
         have = False
         catchup = False
+
+    # Silence past --max-wait: hand control back with whatever we have (usually an
+    # empty batch -- flush() no-ops on an empty buffer). Lets a Monitor-less caller
+    # run its periodic work instead of blocking here until the next record.
+    if wait_deadline is not None and not have and now >= wait_deadline:
+        save_state(off)
+        sys.exit(0)
 
     time.sleep(1)
 

--- a/triggers/call-summary-codex/tuple-call-watcher.py
+++ b/triggers/call-summary-codex/tuple-call-watcher.py
@@ -2,7 +2,7 @@
 """
 Tuple call companion watcher -- known-good, deterministic.
 
-Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [call-id] [transcripts-root]
+Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--max-wait SECS] [--offsets TAG] [call-id] [transcripts-root]
         (it's executable; equivalently `python3 tuple-call-watcher.py ...`)
   --catchup          one-shot: ignore any saved offset, read every file from the
                      start, print that backlog, save offsets, and exit. The
@@ -13,6 +13,12 @@ Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [c
                      either flag the watcher runs continuously (Claude + Monitor),
                      forwarding each poll's new records immediately and letting
                      Monitor re-wake the agent.
+  --max-wait SECS    only with --exit-on-batch: if no records arrive within SECS
+                     seconds, exit anyway with an empty batch, handing control
+                     back to the caller. Without it --exit-on-batch blocks until
+                     the next record -- which never comes in a silent room, so a
+                     poll-loop caller that does periodic work (e.g. a coach's
+                     silence checks) needs this to get a turn during silence.
   --offsets TAG      suffix for the per-session offset file
                      (.tuple-watcher-offsets-TAG), so two agents watching the same
                      call keep separate read positions.
@@ -38,6 +44,7 @@ import glob, os, sys, time
 exit_on_batch = False
 from_start = False
 offsets_tag = None
+max_wait = None
 positional = []
 _args = list(sys.argv[1:])
 _i = 0
@@ -54,6 +61,16 @@ while _i < len(_args):
             sys.stderr.write("tuple-watcher: --offsets needs a tag value\n")
             sys.exit(2)
         offsets_tag = _args[_i]
+    elif a == "--max-wait":
+        _i += 1
+        if _i >= len(_args) or _args[_i].startswith("--"):
+            sys.stderr.write("tuple-watcher: --max-wait needs a seconds value\n")
+            sys.exit(2)
+        try:
+            max_wait = float(_args[_i])
+        except ValueError:
+            sys.stderr.write("tuple-watcher: --max-wait needs a numeric seconds value\n")
+            sys.exit(2)
     else:
         positional.append(a)
     _i += 1
@@ -224,6 +241,12 @@ if from_start:
     sys.exit(0)
 
 
+# --max-wait deadline (only with --exit-on-batch): after this much wall-clock
+# with no flush, exit anyway so a poll-loop caller regains its turn during a
+# silent stretch. Reset on each flushed batch isn't needed -- exit-on-batch exits
+# on flush, so this loop only runs once per invocation.
+wait_deadline = (time.time() + max_wait) if (exit_on_batch and max_wait is not None) else None
+
 while True:
     newdata = collect()
 
@@ -247,6 +270,13 @@ while True:
         buf = []
         have = False
         catchup = False
+
+    # Silence past --max-wait: hand control back with whatever we have (usually an
+    # empty batch -- flush() no-ops on an empty buffer). Lets a Monitor-less caller
+    # run its periodic work instead of blocking here until the next record.
+    if wait_deadline is not None and not have and now >= wait_deadline:
+        save_state(off)
+        sys.exit(0)
 
     time.sleep(1)
 

--- a/triggers/call-summary-opencode/tuple-call-watcher.py
+++ b/triggers/call-summary-opencode/tuple-call-watcher.py
@@ -2,7 +2,7 @@
 """
 Tuple call companion watcher -- known-good, deterministic.
 
-Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [call-id] [transcripts-root]
+Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--max-wait SECS] [--offsets TAG] [call-id] [transcripts-root]
         (it's executable; equivalently `python3 tuple-call-watcher.py ...`)
   --catchup          one-shot: ignore any saved offset, read every file from the
                      start, print that backlog, save offsets, and exit. The
@@ -13,6 +13,12 @@ Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [c
                      either flag the watcher runs continuously (Claude + Monitor),
                      forwarding each poll's new records immediately and letting
                      Monitor re-wake the agent.
+  --max-wait SECS    only with --exit-on-batch: if no records arrive within SECS
+                     seconds, exit anyway with an empty batch, handing control
+                     back to the caller. Without it --exit-on-batch blocks until
+                     the next record -- which never comes in a silent room, so a
+                     poll-loop caller that does periodic work (e.g. a coach's
+                     silence checks) needs this to get a turn during silence.
   --offsets TAG      suffix for the per-session offset file
                      (.tuple-watcher-offsets-TAG), so two agents watching the same
                      call keep separate read positions.
@@ -38,6 +44,7 @@ import glob, os, sys, time
 exit_on_batch = False
 from_start = False
 offsets_tag = None
+max_wait = None
 positional = []
 _args = list(sys.argv[1:])
 _i = 0
@@ -54,6 +61,16 @@ while _i < len(_args):
             sys.stderr.write("tuple-watcher: --offsets needs a tag value\n")
             sys.exit(2)
         offsets_tag = _args[_i]
+    elif a == "--max-wait":
+        _i += 1
+        if _i >= len(_args) or _args[_i].startswith("--"):
+            sys.stderr.write("tuple-watcher: --max-wait needs a seconds value\n")
+            sys.exit(2)
+        try:
+            max_wait = float(_args[_i])
+        except ValueError:
+            sys.stderr.write("tuple-watcher: --max-wait needs a numeric seconds value\n")
+            sys.exit(2)
     else:
         positional.append(a)
     _i += 1
@@ -224,6 +241,12 @@ if from_start:
     sys.exit(0)
 
 
+# --max-wait deadline (only with --exit-on-batch): after this much wall-clock
+# with no flush, exit anyway so a poll-loop caller regains its turn during a
+# silent stretch. Reset on each flushed batch isn't needed -- exit-on-batch exits
+# on flush, so this loop only runs once per invocation.
+wait_deadline = (time.time() + max_wait) if (exit_on_batch and max_wait is not None) else None
+
 while True:
     newdata = collect()
 
@@ -247,6 +270,13 @@ while True:
         buf = []
         have = False
         catchup = False
+
+    # Silence past --max-wait: hand control back with whatever we have (usually an
+    # empty batch -- flush() no-ops on an empty buffer). Lets a Monitor-less caller
+    # run its periodic work instead of blocking here until the next record.
+    if wait_deadline is not None and not have and now >= wait_deadline:
+        save_state(off)
+        sys.exit(0)
 
     time.sleep(1)
 

--- a/triggers/call-summary-pi/tuple-call-watcher.py
+++ b/triggers/call-summary-pi/tuple-call-watcher.py
@@ -2,7 +2,7 @@
 """
 Tuple call companion watcher -- known-good, deterministic.
 
-Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [call-id] [transcripts-root]
+Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--max-wait SECS] [--offsets TAG] [call-id] [transcripts-root]
         (it's executable; equivalently `python3 tuple-call-watcher.py ...`)
   --catchup          one-shot: ignore any saved offset, read every file from the
                      start, print that backlog, save offsets, and exit. The
@@ -13,6 +13,12 @@ Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [c
                      either flag the watcher runs continuously (Claude + Monitor),
                      forwarding each poll's new records immediately and letting
                      Monitor re-wake the agent.
+  --max-wait SECS    only with --exit-on-batch: if no records arrive within SECS
+                     seconds, exit anyway with an empty batch, handing control
+                     back to the caller. Without it --exit-on-batch blocks until
+                     the next record -- which never comes in a silent room, so a
+                     poll-loop caller that does periodic work (e.g. a coach's
+                     silence checks) needs this to get a turn during silence.
   --offsets TAG      suffix for the per-session offset file
                      (.tuple-watcher-offsets-TAG), so two agents watching the same
                      call keep separate read positions.
@@ -38,6 +44,7 @@ import glob, os, sys, time
 exit_on_batch = False
 from_start = False
 offsets_tag = None
+max_wait = None
 positional = []
 _args = list(sys.argv[1:])
 _i = 0
@@ -54,6 +61,16 @@ while _i < len(_args):
             sys.stderr.write("tuple-watcher: --offsets needs a tag value\n")
             sys.exit(2)
         offsets_tag = _args[_i]
+    elif a == "--max-wait":
+        _i += 1
+        if _i >= len(_args) or _args[_i].startswith("--"):
+            sys.stderr.write("tuple-watcher: --max-wait needs a seconds value\n")
+            sys.exit(2)
+        try:
+            max_wait = float(_args[_i])
+        except ValueError:
+            sys.stderr.write("tuple-watcher: --max-wait needs a numeric seconds value\n")
+            sys.exit(2)
     else:
         positional.append(a)
     _i += 1
@@ -224,6 +241,12 @@ if from_start:
     sys.exit(0)
 
 
+# --max-wait deadline (only with --exit-on-batch): after this much wall-clock
+# with no flush, exit anyway so a poll-loop caller regains its turn during a
+# silent stretch. Reset on each flushed batch isn't needed -- exit-on-batch exits
+# on flush, so this loop only runs once per invocation.
+wait_deadline = (time.time() + max_wait) if (exit_on_batch and max_wait is not None) else None
+
 while True:
     newdata = collect()
 
@@ -247,6 +270,13 @@ while True:
         buf = []
         have = False
         catchup = False
+
+    # Silence past --max-wait: hand control back with whatever we have (usually an
+    # empty batch -- flush() no-ops on an empty buffer). Lets a Monitor-less caller
+    # run its periodic work instead of blocking here until the next record.
+    if wait_deadline is not None and not have and now >= wait_deadline:
+        save_state(off)
+        sys.exit(0)
 
     time.sleep(1)
 

--- a/triggers/coach-drama-triangle-claude/README.md
+++ b/triggers/coach-drama-triangle-claude/README.md
@@ -17,7 +17,7 @@ The Drama Triangle framework is embedded into the system prompt. You do **not** 
 
 While you're talking:
 
-- Follows the call with the bundled `tuple-call-watcher.py`: catches up on the backlog, then `Monitor`s a live run so it wakes on new lines (no polling).
+- Follows the call with the bundled `tuple-call-watcher.py`: catches up on the backlog, then follows live — `Monitor`ing a continuous run where the `Monitor` tool is available (the preferred path), or, where it isn't (e.g. Bedrock), looping the watcher in `--exit-on-batch --max-wait` mode over `Bash`.
 - Maps participant IDs to names once from `user_joined` events, then watches **only the lines attributed to you**.
 - On each new line, checks against the Drama Triangle markers in the system prompt.
 - When confidence is high (≥90%), prints a terminal line and fires a desktop notification through the bundled `tuple-notify.sh` (uses `terminal-notifier` for a clickable popup if installed, falls back to `osascript`):
@@ -75,7 +75,7 @@ When `call-transcription-started` fires, Tuple provides `TUPLE_TRIGGER_CALL_ARTI
 3. Writes an executable `launch-coach-drama-triangle-claude.command` wrapper.
 4. Opens it in your preferred terminal (Ghostty → iTerm → Alacritty → Terminal; override with `PREFERRED_TERM`) via `open` (LaunchServices). No AppleScript and no direct binary launch, so no macOS accessibility prompt and no stray windows.
 
-The wrapper starts a login-interactive zsh, changes to the transcripts root, and runs Claude. Claude runs the bundled watcher once to catch up, then `Monitor`s a continuous run for the life of the call, coaching your lines in real time off disk. The watcher follows every session directory for the call, so if transcription stops and restarts mid-call it picks the resumed stream up automatically. A PID file in the transcripts root, keyed by call ID, keeps a second transcription start from launching a duplicate coach. When a `call_ended` event arrives, the session reads the full transcript from disk, writes `drama-evaluation.md` into the active session directory, and fires the "analysis ready" notification.
+The wrapper starts a login-interactive zsh, changes to the transcripts root, and runs Claude. Claude runs the bundled watcher once to catch up, then follows the call for its life — `Monitor`ing a continuous run where `Monitor` is available, or looping `--exit-on-batch` over `Bash` where it isn't — coaching your lines in real time off disk. The watcher follows every session directory for the call, so if transcription stops and restarts mid-call it picks the resumed stream up automatically. A PID file in the transcripts root, keyed by call ID, keeps a second transcription start from launching a duplicate coach. When a `call_ended` event arrives, the session reads the full transcript from disk, writes `drama-evaluation.md` into the active session directory, and fires the "analysis ready" notification.
 
 For local testing without opening a terminal, set `COACH_DRAMA_TRIANGLE_CLAUDE_DRY_RUN=1`; it writes the prompt and launcher and exits.
 

--- a/triggers/coach-drama-triangle-claude/call-transcription-started
+++ b/triggers/coach-drama-triangle-claude/call-transcription-started
@@ -102,7 +102,7 @@ Follow the Setup steps in your appended system prompt. First, catch up on everyt
 
     ./__SESSIONDIR__/tuple-call-watcher.py --catchup --offsets coach-drama-triangle-claude
 
-Use that backlog to map your user's id to a name (via `user_joined` events) and to gauge the conversation so far. Then start the live watcher Monitor as your system prompt describes, return silently, and wait for a wake signal. Keep any catch-up output to yourself unless your user asks.
+Use that backlog to map your user's id to a name (via `user_joined` events) and to gauge the conversation so far. Then start live-follow as your system prompt describes — subscribe with `Monitor` if you have it, otherwise loop the `--exit-on-batch` watcher via `Bash` — and stay otherwise silent. Keep any catch-up output to yourself unless your user asks.
 PROMPT
 # bash 3.2 (macOS default) mangles heredocs inside $()/`` so the prompt is
 # written straight to a file, then placeholders are substituted with sed.

--- a/triggers/coach-drama-triangle-claude/system-prompt.md
+++ b/triggers/coach-drama-triangle-claude/system-prompt.md
@@ -2,7 +2,7 @@ You are a quiet, real-time drama-triangle coach on a live Tuple pair-programming
 
 You watch the live transcript and, when your user just said something with clear drama markers and you can offer a one-line reframe, leave a terminal note plus a best-effort desktop notification. You stay otherwise silent. You never post anywhere external. Your terminal is visible only to your user; call participants cannot hear you or see your output.
 
-Don't poll on a timer — subscribe to the live transcript watcher so you wake on signal, not on schedule. Keep a long fallback timer as a safety net.
+Follow the bundled watcher rather than polling on a timer of your own. **Prefer `Monitor`** — you wake on signal, not on schedule. But if `Monitor` isn't in your toolset (some hosted deployments, e.g. Bedrock, disable it), fall back to a `Bash` loop of the watcher in `--exit-on-batch --max-wait` mode (see Setup). Under `Monitor`, keep a long fallback timer as a safety net.
 
 ## Whose lines you coach
 
@@ -18,18 +18,18 @@ Do all of these once at the very start, then return without speaking:
 
        ./<session-dir>/tuple-call-watcher.py --catchup --offsets coach-drama-triangle-claude
 
-   `<session-dir>` is the active session directory given in your kickoff prompt. Then start live monitoring against the same script and offsets file:
+   `<session-dir>` is the active session directory given in your kickoff prompt. Then start live-follow against the same script and offsets file (no gap, no repeat). **Prefer `Monitor`:**
 
    `Monitor(command: "./<session-dir>/tuple-call-watcher.py --offsets coach-drama-triangle-claude", description: "Tuple transcript watcher", persistent: true)`.
 
-   Use Monitor specifically — each wake delivers the new records as stdout, which is the only way the session learns new lines have arrived. `Bash run_in_background` writes to a log file that never wakes you. Each wake delivers one or more tagged lines, one record each:
+   Each wake delivers the new records as stdout — the lowest-latency way the session learns new lines have arrived; `Bash run_in_background` writes to a log file that never wakes you, so don't use it. **If you have no `Monitor` tool** (e.g. Bedrock): follow with a `Bash` loop instead — run `./<session-dir>/tuple-call-watcher.py --exit-on-batch --max-wait 300 --offsets coach-drama-triangle-claude`, handle the result, then run it again. Each run blocks until the next records arrive (or returns an empty batch after ~300s of silence — nothing to act on; say nothing and re-run). Don't end your turn between runs; the call keeps going. Either way each batch is one or more tagged lines, one record each:
 
        T|<session-dir>|<json-record>   a transcriptions.jsonl record
        E|<session-dir>|<json-record>   an events.jsonl record
 
    Parse the `<json-record>` portion of each line (see **File schemas** under **Watcher reference**). The watcher follows every session directory of this call, including mid-call restarts, and forwards records at conversation speed.
 2. **Map call participants from `user_joined` events.** During catch-up the `E|` lines carry `user_joined` records with `user` and `user_id`; build the id→name map from them (and from any later `user_joined` events that arrive live). Identify your user's `user_id` and name. From here on, only evaluate transcript records whose `user_id` matches your user. Other speakers' lines are context only.
-3. **Set a fallback wake** for ~25 minutes — only as a backstop if the watcher dies silently. The watcher is your primary wake signal.
+3. **Set a fallback wake** — *only* under `Monitor`: ~25 minutes, as a backstop if the watcher dies silently. Under the `Bash` loop you set no timer — you re-run the watcher continuously, so there's nothing to back up. The watcher is your primary wake signal either way.
 4. **Initialize per-call state** in your head:
    - `flagged_items`: [] (every marker you noticed, fired or not — for end-of-call summary)
 
@@ -37,7 +37,7 @@ After setup, end your turn silently.
 
 ## On each wake
 
-Wake sources: a batch of `T|`/`E|` tagged lines from the watcher Monitor, fallback timer, terminal input. Parse the `<json-record>` portion of each tagged line first.
+Wake sources: a batch of `T|`/`E|` tagged lines from the watcher (the `Monitor`, or an `--exit-on-batch` run), the fallback timer (`Monitor` path only), and terminal input. Under the `Bash` loop a watcher run may return empty after its `--max-wait` — a quiet stretch with no markers to act on; say nothing and run the watcher again. Parse the `<json-record>` portion of each tagged line first.
 
 For each new transcription record (`T|` line) attributed to your user, walk these gates in order:
 
@@ -169,7 +169,8 @@ Output is yours alone — call participants don't see it. You follow the call wi
 Run it as `./<session-dir>/tuple-call-watcher.py` (it's executable). Modes:
 
 - `--catchup --offsets coach-drama-triangle-claude` — one-shot: print the whole backlog as tagged lines, save the read position, and exit. Run this once via `Bash` at setup.
-- `--offsets coach-drama-triangle-claude` (no mode flag) — continuous: stream new records forever as they arrive. This is the run you put under `Monitor`. Sharing the `--offsets coach-drama-triangle-claude` file with the catch-up run means it resumes exactly where catch-up stopped — no gap, no repeat.
+- `--offsets coach-drama-triangle-claude` (no mode flag) — continuous: stream new records forever as they arrive. This is the run you put under `Monitor` (preferred). Sharing the `--offsets coach-drama-triangle-claude` file with the catch-up run means it resumes exactly where catch-up stopped — no gap, no repeat.
+- `--exit-on-batch --max-wait 300 --offsets coach-drama-triangle-claude` — poll mode: block until the next batch (or ~300s of silence), print it, and exit. Loop this via `Bash` when you have no `Monitor` tool; an empty return is just a quiet stretch.
 
 The optional `--offsets TAG` is a per-agent resume file so two agents watching the same call keep separate positions; use the tag `coach-drama-triangle-claude`. A trailing `<call-id>` argument overrides the followed call (you won't normally need it).
 
@@ -206,7 +207,7 @@ Keep terminal output short — your user is mid-conversation and only sees it wh
 
 ## On checkpoint
 
-When transcription stops mid-call (a `recording_stopped` event with no `call_ended`), produce a checkpoint summary in the terminal: notifications fired, items you flagged but didn't fire on, any patterns you've noticed across the call so far. Stay quiet, keep the watcher Monitor running — it follows the next session directory automatically when transcription resumes. Do not tear anything down.
+When transcription stops mid-call (a `recording_stopped` event with no `call_ended`), produce a checkpoint summary in the terminal: notifications fired, items you flagged but didn't fire on, any patterns you've noticed across the call so far. Stay quiet and keep following — the `Monitor` (it follows the next session directory automatically when transcription resumes), or the `--exit-on-batch` loop. Do not tear anything down.
 
 ## On call end — write the evaluation
 
@@ -214,7 +215,7 @@ The definitive call-ended signal is a `call_ended` event (category `call_ended`)
 
 When `call_ended` confirms call end, switch from real-time coach to analyst and produce the wholesale **call evaluation**. Your real-time coaching watched only your user's lines; the evaluation is broader — analyze **every participant** from the full transcript.
 
-1. **Stop the watcher Monitor.** `TaskList`, then `TaskStop` the watcher task. Cancel the fallback timer.
+1. **Stop following the call.** If you used `Monitor`, `TaskList` then `TaskStop` the watcher task; if you used the `Bash` loop, just stop re-running it. Cancel any fallback timer.
 2. **Read the full transcript from disk.** Don't rely on memory of the live batches — read the complete record, scoped to this call. Your cwd is the transcripts root, which also holds other calls' directories, so glob by this call's id: `find . -path './*@<call-id>/transcriptions.jsonl' | sort`, then Read each in chronological order (there may be several if transcription was stopped and restarted). `<call-id>` is the call-id from your active session directory name (everything after `@`). Pull participant names from the matching `events.jsonl` files (`user_joined` events).
 3. **Write `drama-evaluation.md` into the active session dir `./<session-dir>/`** (given in your kickoff prompt) using the structure below. Use the first 8 characters of the call-id as the `<short-id>`. Lean on what you noticed live (your fired notifications and `flagged_items`), but ground every claim in an actual quote from the transcript.
 4. **Leave a terminal note plus a best-effort desktop notification** pointing to the file (see **Evaluation notification** below): print one short terminal line confirming the path, fire the helper, and end your turn.

--- a/triggers/coach-drama-triangle-claude/tuple-call-watcher.py
+++ b/triggers/coach-drama-triangle-claude/tuple-call-watcher.py
@@ -2,7 +2,7 @@
 """
 Tuple call companion watcher -- known-good, deterministic.
 
-Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [call-id] [transcripts-root]
+Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--max-wait SECS] [--offsets TAG] [call-id] [transcripts-root]
         (it's executable; equivalently `python3 tuple-call-watcher.py ...`)
   --catchup          one-shot: ignore any saved offset, read every file from the
                      start, print that backlog, save offsets, and exit. The
@@ -13,6 +13,12 @@ Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [c
                      either flag the watcher runs continuously (Claude + Monitor),
                      forwarding each poll's new records immediately and letting
                      Monitor re-wake the agent.
+  --max-wait SECS    only with --exit-on-batch: if no records arrive within SECS
+                     seconds, exit anyway with an empty batch, handing control
+                     back to the caller. Without it --exit-on-batch blocks until
+                     the next record -- which never comes in a silent room, so a
+                     poll-loop caller that does periodic work (e.g. a coach's
+                     silence checks) needs this to get a turn during silence.
   --offsets TAG      suffix for the per-session offset file
                      (.tuple-watcher-offsets-TAG), so two agents watching the same
                      call keep separate read positions.
@@ -38,6 +44,7 @@ import glob, os, sys, time
 exit_on_batch = False
 from_start = False
 offsets_tag = None
+max_wait = None
 positional = []
 _args = list(sys.argv[1:])
 _i = 0
@@ -54,6 +61,16 @@ while _i < len(_args):
             sys.stderr.write("tuple-watcher: --offsets needs a tag value\n")
             sys.exit(2)
         offsets_tag = _args[_i]
+    elif a == "--max-wait":
+        _i += 1
+        if _i >= len(_args) or _args[_i].startswith("--"):
+            sys.stderr.write("tuple-watcher: --max-wait needs a seconds value\n")
+            sys.exit(2)
+        try:
+            max_wait = float(_args[_i])
+        except ValueError:
+            sys.stderr.write("tuple-watcher: --max-wait needs a numeric seconds value\n")
+            sys.exit(2)
     else:
         positional.append(a)
     _i += 1
@@ -224,6 +241,12 @@ if from_start:
     sys.exit(0)
 
 
+# --max-wait deadline (only with --exit-on-batch): after this much wall-clock
+# with no flush, exit anyway so a poll-loop caller regains its turn during a
+# silent stretch. Reset on each flushed batch isn't needed -- exit-on-batch exits
+# on flush, so this loop only runs once per invocation.
+wait_deadline = (time.time() + max_wait) if (exit_on_batch and max_wait is not None) else None
+
 while True:
     newdata = collect()
 
@@ -247,6 +270,13 @@ while True:
         buf = []
         have = False
         catchup = False
+
+    # Silence past --max-wait: hand control back with whatever we have (usually an
+    # empty batch -- flush() no-ops on an empty buffer). Lets a Monitor-less caller
+    # run its periodic work instead of blocking here until the next record.
+    if wait_deadline is not None and not have and now >= wait_deadline:
+        save_state(off)
+        sys.exit(0)
 
     time.sleep(1)
 

--- a/triggers/coach-pairing-claude/README.md
+++ b/triggers/coach-pairing-claude/README.md
@@ -17,7 +17,7 @@ The pairing framework is embedded into the system prompt. You do **not** need an
 
 While you're pairing:
 
-- Follows the call with **Tuple's bundled watcher** (`tuple-call-watcher.py`, shipped with this trigger): it catches up on the backlog once, then `Monitor`s a continuous run that wakes the coach on each new batch of transcript read off disk (no polling), plus a short fallback timer so it can notice *silences*. A quiet navigator or a grinding session produce no transcript to wake on.
+- Follows the call with **Tuple's bundled watcher** (`tuple-call-watcher.py`, shipped with this trigger): it catches up on the backlog once, then follows live. Where the `Monitor` tool is available (the preferred path) it `Monitor`s a continuous run that wakes the coach on each new batch of transcript read off disk, plus a short fallback timer so it can notice *silences*. Where `Monitor` is unavailable — e.g. on Bedrock — it falls back to looping the watcher in `--exit-on-batch --max-wait` mode over `Bash`, where each timed-out empty return is that same silence tick. A quiet navigator or a grinding session produce no transcript to wake on, which is why the silence check matters.
 - Maps both participants to names once from `user_joined` events, and tracks lightweight session state: talk-time balance, who last spoke, whether a goal was set, and how long it's been since a break or swap.
 - On each new line (or fallback tick), checks against the pairing smells in the system prompt.
 - When confidence is high, prints a terminal line and fires a desktop notification through the bundled `tuple-notify.sh` (uses `terminal-notifier` for a clickable popup if installed, falls back to `osascript`):

--- a/triggers/coach-pairing-claude/call-transcription-started
+++ b/triggers/coach-pairing-claude/call-transcription-started
@@ -108,7 +108,7 @@ Follow the Setup steps in your appended system prompt. First, catch up on everyt
 
     ./__SESSIONDIR__/tuple-call-watcher.py --catchup --offsets coach-pairing-claude
 
-Then return silently and wait for a wake signal.
+Then start live-follow per Setup — subscribe with `Monitor` if you have it, otherwise loop the `--exit-on-batch` watcher via `Bash` — and otherwise stay silent.
 PROMPT
 # bash 3.2 (macOS default) mangles heredocs inside $()/`` so the prompt is
 # written straight to a file, then placeholders are substituted with sed.

--- a/triggers/coach-pairing-claude/system-prompt.md
+++ b/triggers/coach-pairing-claude/system-prompt.md
@@ -2,7 +2,7 @@ You are a quiet, real-time pairing coach on a live Tuple pair-programming call. 
 
 You watch the live transcript and fire a **terminal note plus a best-effort desktop notification** when you spot a clear smell and can offer a one-line move your user could make to fix it. You stay otherwise silent. You never post anywhere external. Your terminal is visible only to your user; the other participant cannot hear you or see your output.
 
-Don't poll on a timer — Monitor the bundled watcher so you wake on signal, not on schedule. Keep a functional fallback timer too: many pairing smells are *silences* (a quiet navigator, a driver who stopped narrating), and silence produces no transcript lines to wake you, so the timer is how you notice nothing is happening.
+Follow the bundled watcher rather than polling on a timer of your own. **Prefer `Monitor`** — you wake on signal, not on schedule. But if `Monitor` isn't in your toolset (some hosted deployments, e.g. Bedrock, disable it), fall back to a `Bash` loop of the watcher in `--exit-on-batch --max-wait` mode (see Setup). Either way, keep a functional silence check: many pairing smells are *silences* (a quiet navigator, a driver who stopped narrating), and silence produces no transcript lines — under `Monitor` a fallback timer is how you notice nothing is happening; under the `Bash` loop each timed-out empty return is that same tick.
 
 ## Whose session you coach
 
@@ -15,9 +15,9 @@ Identify both participants once at setup so you can attribute lines. Optional id
 Do all of these once at the very start, then return without speaking:
 
 0. **Catch up first.** Before subscribing, read everything said before you joined. Run the bundled watcher once via Bash in catch-up mode: `./<session-dir>/tuple-call-watcher.py --catchup --offsets coach-pairing-claude` (the active session dir is given in your kickoff prompt). It prints the whole backlog as `T|`/`E|` tagged lines and saves its read position to the shared `coach-pairing-claude` offsets file, so the live Monitor below resumes exactly where catch-up stopped — no gap, no repeat. Use this to recover the goal-setting, the talk-time so far, and who's been driving.
-1. **Subscribe to the watcher with Monitor:** `Monitor(command: "./<session-dir>/tuple-call-watcher.py --offsets coach-pairing-claude", description: "Tuple transcript watcher", persistent: true)` (same session dir, same offsets file). Use Monitor specifically — each batch becomes a wake notification, which is the only way the session learns new lines have arrived. `Bash run_in_background` writes to a log file that never wakes you. Each wake delivers one or more tagged lines: `T|<session-dir>|<json-record>` for a `transcriptions.jsonl` record and `E|<session-dir>|<json-record>` for an `events.jsonl` record. Parse the `<json-record>` portion of each. The watcher batches on its own and follows every session dir of this call (including mid-call transcription restarts), so you don't set an interval.
+1. **Follow the live transcript** — same `--offsets coach-pairing-claude` file as the catch-up, so it resumes exactly where catch-up stopped (no gap, no repeat). **Prefer `Monitor`:** `Monitor(command: "./<session-dir>/tuple-call-watcher.py --offsets coach-pairing-claude", description: "Tuple transcript watcher", persistent: true)`. Each batch becomes a wake notification — the lowest-latency way the session learns new lines have arrived; `Bash run_in_background` writes to a log file that never wakes you, so don't use it. **If you have no `Monitor` tool** (e.g. Bedrock): follow with a `Bash` loop instead — run `./<session-dir>/tuple-call-watcher.py --exit-on-batch --max-wait 120 --offsets coach-pairing-claude`, handle the result, then run it again. Each run blocks until the next records arrive (or returns an empty batch after ~120s of silence — that's your silence tick, see step 3). Don't end your turn between runs; the call keeps going. Either way each delivered line is tagged, one record each: `T|<session-dir>|<json-record>` for a `transcriptions.jsonl` record and `E|<session-dir>|<json-record>` for an `events.jsonl` record. Parse the `<json-record>` portion of each. The watcher batches on its own and follows every session dir of this call (including mid-call transcription restarts), so you don't set an interval.
 2. **Map call participants:** resolve participant IDs to names from `user_joined` events, delivered as `E|` lines on the stream and present in each session's `events.jsonl` (`{category: "user_joined", user, ...}`). Identify your user and the other participant. There's no reliable screen-share/driver signal off disk, so infer who's driving from who's narrating actions or who clearly has the keyboard in context, rather than a definitive state field — re-infer it as the conversation makes it obvious.
-3. **Set a functional fallback wake for ~6 minutes.** Unlike a pure backstop, this timer does real work: when both people go quiet (deep focus, a silent driver, a grinding session with no breaks) the stream stays silent and the fallback is your only way to notice. Re-arm it each time it fires.
+3. **Arrange a functional silence check (every few minutes).** Unlike a pure backstop, this does real work: when both people go quiet (deep focus, a silent driver, a grinding session with no breaks) the stream stays silent and this is your only way to notice. **Under `Monitor`:** set a fallback timer for ~6 minutes and re-arm it each time it fires. **Under the `Bash` loop:** don't set a timer — each empty `--max-wait` return (a watcher run that printed no records) *is* a silence tick; run the temporal checks, then loop the watcher again.
 4. **Initialize per-call state** in your head:
    - `last_spoke_at`: per participant — for detecting a quiet pair
    - `driver_since`: when the current driver took the keyboard, if you can infer it from who's narrating actions — for swap nudges
@@ -30,11 +30,11 @@ After setup, end your turn silently.
 
 ## On each wake
 
-Wake sources: a watcher batch from the Monitor, the fallback timer, terminal input.
+Wake sources: a watcher batch (new `T|`/`E|` lines — from the `Monitor`, or from an `--exit-on-batch` run), a silence tick (the fallback timer firing, or an empty `--exit-on-batch` return), and terminal input.
 
 **On a watcher batch** (new `T|`/`E|` lines): parse the `<json-record>` in each, update `last_spoke_at` for whoever spoke (resolve `user_id` to a name via the `user_joined` events you mapped at setup), then walk each new transcript line through the gates below. Also flip `goal_stated` / reset `last_break_or_swap_at` when you hear the pair set a goal, take a break, or swap drivers.
 
-**On the fallback timer** (no lines arrived): check the *temporal* smells — has one participant been silent a long time? Has the session run a long time with no break or swap? Has the first stretch passed with no goal stated? Re-arm the timer.
+**On a silence tick** (no lines arrived — the fallback timer fired, or an `--exit-on-batch` run returned empty): check the *temporal* smells — has one participant been silent a long time? Has the session run a long time with no break or swap? Has the first stretch passed with no goal stated? Then re-arm the timer (`Monitor`) or loop the watcher again (`Bash`).
 
 For each candidate smell, walk these gates in order:
 
@@ -181,7 +181,8 @@ When in doubt, the cost of a missed nudge is one less line in the end-of-call re
 Output is yours alone — call participants don't see it. You follow the call with Tuple's bundled watcher, `./<session-dir>/tuple-call-watcher.py` (the active session dir is given in your kickoff prompt). It self-locates from its own path: it derives the call id and the transcripts root, then follows **every** session dir matching `./*@<call-id>/`, including the new dir created when transcription stops and restarts mid-call.
 
 - `./<session-dir>/tuple-call-watcher.py --catchup --offsets coach-pairing-claude` — one-shot: print the entire backlog and exit. Run this once via Bash at setup.
-- `./<session-dir>/tuple-call-watcher.py --offsets coach-pairing-claude` — continuous: stream batches forever. This is what you Monitor for live updates.
+- `./<session-dir>/tuple-call-watcher.py --offsets coach-pairing-claude` — continuous: stream batches forever. This is what you Monitor for live updates (preferred).
+- `./<session-dir>/tuple-call-watcher.py --exit-on-batch --max-wait 120 --offsets coach-pairing-claude` — poll mode: block until the next batch (or ~120s of silence), print it, and exit. Loop this via `Bash` when you have no `Monitor` tool; an empty return after a silent stretch is your silence tick.
 - `--offsets coach-pairing-claude` gives this coach its own resume file so catch-up and the live run share one read position with no gap or repeat. Always pass it.
 
 Each emitted line is tagged:
@@ -215,7 +216,7 @@ Keep terminal output short — your user is mid-session and only sees it when th
 
 ## On checkpoint
 
-When transcription stops mid-call (a `recording_stopped` event arrives, but no `call_ended`), produce a checkpoint summary in the terminal: notifications fired, smells you flagged but didn't fire on, and the rough talk-time balance so far. Stay quiet, keep the watcher Monitor running. A `recording_stopped` event alone is only a checkpoint, not call end — do not tear anything down.
+When transcription stops mid-call (a `recording_stopped` event arrives, but no `call_ended`), produce a checkpoint summary in the terminal: notifications fired, smells you flagged but didn't fire on, and the rough talk-time balance so far. Stay quiet and keep following — the `Monitor` (it picks up the next session dir automatically when transcription resumes), or the `--exit-on-batch` loop. A `recording_stopped` event alone is only a checkpoint, not call end — do not tear anything down.
 
 ## On call end — write the session retro
 
@@ -223,7 +224,7 @@ The definitive call-ended signal is a `call_ended` event (category `call_ended`)
 
 When a `call_ended` event confirms call end, switch from real-time coach to analyst and produce the wholesale **session retro**:
 
-1. **Stop the watcher Monitor.** `TaskList`, then `TaskStop` the watcher task. Cancel the fallback timer.
+1. **Stop following the call.** If you used `Monitor`, `TaskList` then `TaskStop` the watcher task; if you used the `Bash` loop, just stop re-running it. Cancel any fallback timer.
 2. **Read the full transcript from disk — scoped to this call.** Don't rely on memory of the stream — read the complete record. Your cwd is the shared transcripts root, which holds many calls, so scope to this call's session dirs: `find . -path './*@<call-id>/transcriptions.jsonl' | sort` (the call id is given in your kickoff prompt), then Read each in chronological order (there may be several if transcription was stopped and restarted). Pull participant names from the `transcriptions.jsonl` `user_id` fields resolved against the `user_joined` events in each `events.jsonl`.
 3. **Write `pairing-evaluation.md` into the active session dir** (`./<session-dir>/`, not the cwd root, which holds other calls) using the structure below. Use the first 8 characters of the call id as the `<short-id>`. Lean on what you already noticed live (your fired notifications and `flagged_items`), but ground every claim in an actual quote from the transcript.
 4. **Fire one notification** pointing to the file (see **Retro notification** below), print one short terminal line confirming the path, and end your turn.

--- a/triggers/coach-pairing-claude/tuple-call-watcher.py
+++ b/triggers/coach-pairing-claude/tuple-call-watcher.py
@@ -2,7 +2,7 @@
 """
 Tuple call companion watcher -- known-good, deterministic.
 
-Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [call-id] [transcripts-root]
+Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--max-wait SECS] [--offsets TAG] [call-id] [transcripts-root]
         (it's executable; equivalently `python3 tuple-call-watcher.py ...`)
   --catchup          one-shot: ignore any saved offset, read every file from the
                      start, print that backlog, save offsets, and exit. The
@@ -13,6 +13,12 @@ Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [c
                      either flag the watcher runs continuously (Claude + Monitor),
                      forwarding each poll's new records immediately and letting
                      Monitor re-wake the agent.
+  --max-wait SECS    only with --exit-on-batch: if no records arrive within SECS
+                     seconds, exit anyway with an empty batch, handing control
+                     back to the caller. Without it --exit-on-batch blocks until
+                     the next record -- which never comes in a silent room, so a
+                     poll-loop caller that does periodic work (e.g. a coach's
+                     silence checks) needs this to get a turn during silence.
   --offsets TAG      suffix for the per-session offset file
                      (.tuple-watcher-offsets-TAG), so two agents watching the same
                      call keep separate read positions.
@@ -38,6 +44,7 @@ import glob, os, sys, time
 exit_on_batch = False
 from_start = False
 offsets_tag = None
+max_wait = None
 positional = []
 _args = list(sys.argv[1:])
 _i = 0
@@ -54,6 +61,16 @@ while _i < len(_args):
             sys.stderr.write("tuple-watcher: --offsets needs a tag value\n")
             sys.exit(2)
         offsets_tag = _args[_i]
+    elif a == "--max-wait":
+        _i += 1
+        if _i >= len(_args) or _args[_i].startswith("--"):
+            sys.stderr.write("tuple-watcher: --max-wait needs a seconds value\n")
+            sys.exit(2)
+        try:
+            max_wait = float(_args[_i])
+        except ValueError:
+            sys.stderr.write("tuple-watcher: --max-wait needs a numeric seconds value\n")
+            sys.exit(2)
     else:
         positional.append(a)
     _i += 1
@@ -224,6 +241,12 @@ if from_start:
     sys.exit(0)
 
 
+# --max-wait deadline (only with --exit-on-batch): after this much wall-clock
+# with no flush, exit anyway so a poll-loop caller regains its turn during a
+# silent stretch. Reset on each flushed batch isn't needed -- exit-on-batch exits
+# on flush, so this loop only runs once per invocation.
+wait_deadline = (time.time() + max_wait) if (exit_on_batch and max_wait is not None) else None
+
 while True:
     newdata = collect()
 
@@ -247,6 +270,13 @@ while True:
         buf = []
         have = False
         catchup = False
+
+    # Silence past --max-wait: hand control back with whatever we have (usually an
+    # empty batch -- flush() no-ops on an empty buffer). Lets a Monitor-less caller
+    # run its periodic work instead of blocking here until the next record.
+    if wait_deadline is not None and not have and now >= wait_deadline:
+        save_state(off)
+        sys.exit(0)
 
     time.sleep(1)
 

--- a/triggers/sidekick-claude/README.md
+++ b/triggers/sidekick-claude/README.md
@@ -11,7 +11,7 @@ When `call-transcription-started` fires, this trigger opens your preferred termi
 - **Answers when addressed.** Say "Claude, ..." (or type into the terminal) and it responds to that turn, then keeps listening.
 - **Summarizes.** It writes a checkpoint summary when recording stops and a final summary (decisions, action items, open threads) when the call ends.
 
-Claude follows the call with **Tuple's bundled watcher** (`tuple-call-watcher.py`), shipped with this trigger and run verbatim: a fixed, deterministic script rather than a poll loop the model re-authors each session. Claude runs it once via `Bash --catchup` to read the backlog, then `Monitor`s a continuous run for live updates. It launches with `claude --allowed-tools Read Bash Monitor --name "Tuple Sidekick - Claude"`.
+Claude follows the call with **Tuple's bundled watcher** (`tuple-call-watcher.py`), shipped with this trigger and run verbatim: a fixed, deterministic script rather than a poll loop the model re-authors each session. Claude runs it once via `Bash --catchup` to read the backlog, then follows live. When the `Monitor` tool is available (the preferred path), it `Monitor`s a continuous run so it wakes on each emit. When `Monitor` is unavailable — e.g. on Bedrock, where it's disabled — Claude falls back to looping the watcher in `--exit-on-batch` mode over `Bash`, the same poll-by-re-execution the Codex sidekick uses. It launches with `claude --allowed-tools Read Bash Monitor --name "Tuple Sidekick - Claude"`.
 
 ## Choosing your terminal
 

--- a/triggers/sidekick-claude/call-transcription-started
+++ b/triggers/sidekick-claude/call-transcription-started
@@ -65,7 +65,7 @@ fi
 cat > "${PROMPT_FILE}.tmpl" <<'PROMPT'
 You are a real-time companion on a live Tuple pair-programming call. Your working directory is the Tuple transcripts root, which holds one directory per transcription session, each named `<timestamp>@<call-id>`. The active session for *this* call is `./__SESSIONDIR__/`, holding `events.jsonl` and `transcriptions.jsonl` (one JSON record per line). Transcription can stop and restart mid-call; each restart creates a new session directory at the root whose name ends `@__CALLID__`, so this call's full session set is every directory matching `./*@__CALLID__/` — plan for it to grow. Other root directories are prior calls — available if the user asks about earlier discussions, but the active transcription is your focus.
 
-You interact with one human: the user at this terminal. Other call participants don't see your output. You follow this call with Tuple's bundled watcher script: one `Bash` run to catch up, then a `Monitor`'d run for live updates (see Catch up first / Watcher). `Read` is available too, for looking something up or revisiting a past call.
+You interact with one human: the user at this terminal. Other call participants don't see your output. You follow this call with Tuple's bundled watcher script: one `Bash` run to catch up, then a live-follow loop — via `Monitor` if you have it, otherwise a `Bash` poll (see Catch up first / Watcher). `Read` is available too, for looking something up or revisiting a past call.
 
 ## Catch up first
 
@@ -86,20 +86,26 @@ If a field looks unfamiliar, read a few lines to confirm shape first.
 
 ## Watcher
 
-Once you've caught up, start live monitoring. Subscribe via `Monitor` to the same script — same `--offsets claude` file, so it resumes exactly where the catch-up stopped (no gap, no repeat):
-
-    ./__SESSIONDIR__/tuple-call-watcher.py --offsets claude
-
-It follows every session directory of this call (including mid-call restarts) and forwards new records as they arrive, at conversation speed. Each `Monitor` wake delivers one or more tagged lines:
+Once you've caught up, follow the call live. **Prefer `Monitor`** — it wakes you on each emit, the lowest-latency, lowest-cost way to follow. Use the `Bash` poll fallback only when `Monitor` isn't in your toolset (some hosted deployments, e.g. Bedrock, disable it). Either way the watcher resumes exactly where the catch-up stopped via the shared `--offsets claude` file (no gap, no repeat), and forwards every session directory of this call, including mid-call restarts. Each delivered line is tagged:
 
     T|<session-dir>|<json-record>   a transcriptions.jsonl record
     E|<session-dir>|<json-record>   an events.jsonl record
 
-`Monitor` truncates a large notification (and any over-long line), marking the cut with `...(truncated)`. Live batches are small and usually fit, but if a record arrives carrying that marker, `Read` it from the session's `transcriptions.jsonl` to recover the full text. No data is lost — the files always hold it all.
+**Preferred — `Monitor`:** subscribe to the continuous watcher:
+
+    ./__SESSIONDIR__/tuple-call-watcher.py --offsets claude
+
+It forwards new records as they arrive, at conversation speed, and each `Monitor` wake delivers one or more tagged lines. Subscribe, then end your turn and wait for records. `Monitor` truncates a large notification (and any over-long line), marking the cut with `...(truncated)`. Live batches are small and usually fit, but if a record arrives carrying that marker, `Read` it from the session's `transcriptions.jsonl` to recover the full text. No data is lost — the files always hold it all.
+
+**Fallback — `Bash` poll (only when `Monitor` is unavailable):** do **not** run the continuous command above under plain `Bash` — its live mode never exits, so the turn would hang forever and nothing would emit. Instead loop the watcher in `--exit-on-batch` mode: run it, handle the batch, run it again.
+
+    ./__SESSIONDIR__/tuple-call-watcher.py --exit-on-batch --offsets claude
+
+Each run blocks until new records arrive, gathers a brief batch (a ~1s pause, or up to ~15s of continuous speech), prints it, and exits. Handle the output and **run the same command again**. The call keeps going between runs, so don't end your turn (until `call_ended`), and don't daemonize, detach, or background the watcher. If a run ever returns no records, say nothing and run it again.
 
 ## Handling each batch
 
-You're a real-time companion for the whole call — log as it happens. Each live wake delivers one or more `T|`/`E|` tagged lines (described above). Parse the `<json-record>` portion of each. Log every record from transcriptions and interesting records from events (especially user joined/left, but NOT user started/stopped sending audio) as a dot-line:
+You're a real-time companion for the whole call — log as it happens. Each live batch delivers one or more `T|`/`E|` tagged lines (described above). Parse the `<json-record>` portion of each. Log every record from transcriptions and interesting records from events (especially user joined/left, but NOT user started/stopped sending audio) as a dot-line:
 
     · HH:MM:SS <speaker_or_event>: <text-or-category>
 
@@ -113,14 +119,15 @@ A line addresses you when "Claude" appears as a vocative — at the start of an 
 
 The user can type directly into this terminal — to address you or ask a question. Treat the message as one event among many. Reply, then immediately resume polling for new transcript records. Don't sit idle waiting for the next user line. The call is still happening even when the user is typing.
 
-To start: catch up first (one `Bash` run + a brief summary), then start the live `Monitor` watcher and end your turn, waiting for records.
+To start: catch up first (one `Bash` run + a brief summary), then start live-follow. With `Monitor`: subscribe and end your turn, waiting for records. Without it: loop the `--exit-on-batch` watcher via `Bash` and keep it going — don't end your turn until `call_ended`.
 
 ## Following later calls (only if asked)
 
 Your focus is this call. But if the user asks you to keep going past it — e.g. to follow them into their next call — watch the transcripts root (your cwd) for a new `<timestamp>@<call-id>` directory whose call-id differs from this one's (`__CALLID__`). When one appears, catch up on it and monitor it exactly as you did here, but pass its call-id as the last argument:
 
-    ./__SESSIONDIR__/tuple-call-watcher.py --catchup --offsets claude <new-call-id>   # catch up
-    ./__SESSIONDIR__/tuple-call-watcher.py --offsets claude <new-call-id>             # then Monitor live
+    ./__SESSIONDIR__/tuple-call-watcher.py --catchup --offsets claude <new-call-id>          # catch up
+    ./__SESSIONDIR__/tuple-call-watcher.py --offsets claude <new-call-id>                    # then follow live (Monitor)
+    ./__SESSIONDIR__/tuple-call-watcher.py --exit-on-batch --offsets claude <new-call-id>    # or loop this if no Monitor
 
 The script lives in this call's dir but follows whatever call-id you pass; its offset files live in the target call's dirs, so reusing `--offsets claude` across calls is fine. Don't do this unless the user asks.
 PROMPT

--- a/triggers/sidekick-claude/tuple-call-watcher.py
+++ b/triggers/sidekick-claude/tuple-call-watcher.py
@@ -2,7 +2,7 @@
 """
 Tuple call companion watcher -- known-good, deterministic.
 
-Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [call-id] [transcripts-root]
+Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--max-wait SECS] [--offsets TAG] [call-id] [transcripts-root]
         (it's executable; equivalently `python3 tuple-call-watcher.py ...`)
   --catchup          one-shot: ignore any saved offset, read every file from the
                      start, print that backlog, save offsets, and exit. The
@@ -13,6 +13,12 @@ Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [c
                      either flag the watcher runs continuously (Claude + Monitor),
                      forwarding each poll's new records immediately and letting
                      Monitor re-wake the agent.
+  --max-wait SECS    only with --exit-on-batch: if no records arrive within SECS
+                     seconds, exit anyway with an empty batch, handing control
+                     back to the caller. Without it --exit-on-batch blocks until
+                     the next record -- which never comes in a silent room, so a
+                     poll-loop caller that does periodic work (e.g. a coach's
+                     silence checks) needs this to get a turn during silence.
   --offsets TAG      suffix for the per-session offset file
                      (.tuple-watcher-offsets-TAG), so two agents watching the same
                      call keep separate read positions.
@@ -38,6 +44,7 @@ import glob, os, sys, time
 exit_on_batch = False
 from_start = False
 offsets_tag = None
+max_wait = None
 positional = []
 _args = list(sys.argv[1:])
 _i = 0
@@ -54,6 +61,16 @@ while _i < len(_args):
             sys.stderr.write("tuple-watcher: --offsets needs a tag value\n")
             sys.exit(2)
         offsets_tag = _args[_i]
+    elif a == "--max-wait":
+        _i += 1
+        if _i >= len(_args) or _args[_i].startswith("--"):
+            sys.stderr.write("tuple-watcher: --max-wait needs a seconds value\n")
+            sys.exit(2)
+        try:
+            max_wait = float(_args[_i])
+        except ValueError:
+            sys.stderr.write("tuple-watcher: --max-wait needs a numeric seconds value\n")
+            sys.exit(2)
     else:
         positional.append(a)
     _i += 1
@@ -224,6 +241,12 @@ if from_start:
     sys.exit(0)
 
 
+# --max-wait deadline (only with --exit-on-batch): after this much wall-clock
+# with no flush, exit anyway so a poll-loop caller regains its turn during a
+# silent stretch. Reset on each flushed batch isn't needed -- exit-on-batch exits
+# on flush, so this loop only runs once per invocation.
+wait_deadline = (time.time() + max_wait) if (exit_on_batch and max_wait is not None) else None
+
 while True:
     newdata = collect()
 
@@ -247,6 +270,13 @@ while True:
         buf = []
         have = False
         catchup = False
+
+    # Silence past --max-wait: hand control back with whatever we have (usually an
+    # empty batch -- flush() no-ops on an empty buffer). Lets a Monitor-less caller
+    # run its periodic work instead of blocking here until the next record.
+    if wait_deadline is not None and not have and now >= wait_deadline:
+        save_state(off)
+        sys.exit(0)
 
     time.sleep(1)
 

--- a/triggers/sidekick-codex/tuple-call-watcher.py
+++ b/triggers/sidekick-codex/tuple-call-watcher.py
@@ -2,7 +2,7 @@
 """
 Tuple call companion watcher -- known-good, deterministic.
 
-Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [call-id] [transcripts-root]
+Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--max-wait SECS] [--offsets TAG] [call-id] [transcripts-root]
         (it's executable; equivalently `python3 tuple-call-watcher.py ...`)
   --catchup          one-shot: ignore any saved offset, read every file from the
                      start, print that backlog, save offsets, and exit. The
@@ -13,6 +13,12 @@ Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [c
                      either flag the watcher runs continuously (Claude + Monitor),
                      forwarding each poll's new records immediately and letting
                      Monitor re-wake the agent.
+  --max-wait SECS    only with --exit-on-batch: if no records arrive within SECS
+                     seconds, exit anyway with an empty batch, handing control
+                     back to the caller. Without it --exit-on-batch blocks until
+                     the next record -- which never comes in a silent room, so a
+                     poll-loop caller that does periodic work (e.g. a coach's
+                     silence checks) needs this to get a turn during silence.
   --offsets TAG      suffix for the per-session offset file
                      (.tuple-watcher-offsets-TAG), so two agents watching the same
                      call keep separate read positions.
@@ -38,6 +44,7 @@ import glob, os, sys, time
 exit_on_batch = False
 from_start = False
 offsets_tag = None
+max_wait = None
 positional = []
 _args = list(sys.argv[1:])
 _i = 0
@@ -54,6 +61,16 @@ while _i < len(_args):
             sys.stderr.write("tuple-watcher: --offsets needs a tag value\n")
             sys.exit(2)
         offsets_tag = _args[_i]
+    elif a == "--max-wait":
+        _i += 1
+        if _i >= len(_args) or _args[_i].startswith("--"):
+            sys.stderr.write("tuple-watcher: --max-wait needs a seconds value\n")
+            sys.exit(2)
+        try:
+            max_wait = float(_args[_i])
+        except ValueError:
+            sys.stderr.write("tuple-watcher: --max-wait needs a numeric seconds value\n")
+            sys.exit(2)
     else:
         positional.append(a)
     _i += 1
@@ -224,6 +241,12 @@ if from_start:
     sys.exit(0)
 
 
+# --max-wait deadline (only with --exit-on-batch): after this much wall-clock
+# with no flush, exit anyway so a poll-loop caller regains its turn during a
+# silent stretch. Reset on each flushed batch isn't needed -- exit-on-batch exits
+# on flush, so this loop only runs once per invocation.
+wait_deadline = (time.time() + max_wait) if (exit_on_batch and max_wait is not None) else None
+
 while True:
     newdata = collect()
 
@@ -247,6 +270,13 @@ while True:
         buf = []
         have = False
         catchup = False
+
+    # Silence past --max-wait: hand control back with whatever we have (usually an
+    # empty batch -- flush() no-ops on an empty buffer). Lets a Monitor-less caller
+    # run its periodic work instead of blocking here until the next record.
+    if wait_deadline is not None and not have and now >= wait_deadline:
+        save_state(off)
+        sys.exit(0)
 
     time.sleep(1)
 

--- a/triggers/sidekick-opencode/tuple-call-watcher.py
+++ b/triggers/sidekick-opencode/tuple-call-watcher.py
@@ -2,7 +2,7 @@
 """
 Tuple call companion watcher -- known-good, deterministic.
 
-Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [call-id] [transcripts-root]
+Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--max-wait SECS] [--offsets TAG] [call-id] [transcripts-root]
         (it's executable; equivalently `python3 tuple-call-watcher.py ...`)
   --catchup          one-shot: ignore any saved offset, read every file from the
                      start, print that backlog, save offsets, and exit. The
@@ -13,6 +13,12 @@ Usage:  ./tuple-call-watcher.py [--catchup | --exit-on-batch] [--offsets TAG] [c
                      either flag the watcher runs continuously (Claude + Monitor),
                      forwarding each poll's new records immediately and letting
                      Monitor re-wake the agent.
+  --max-wait SECS    only with --exit-on-batch: if no records arrive within SECS
+                     seconds, exit anyway with an empty batch, handing control
+                     back to the caller. Without it --exit-on-batch blocks until
+                     the next record -- which never comes in a silent room, so a
+                     poll-loop caller that does periodic work (e.g. a coach's
+                     silence checks) needs this to get a turn during silence.
   --offsets TAG      suffix for the per-session offset file
                      (.tuple-watcher-offsets-TAG), so two agents watching the same
                      call keep separate read positions.
@@ -38,6 +44,7 @@ import glob, os, sys, time
 exit_on_batch = False
 from_start = False
 offsets_tag = None
+max_wait = None
 positional = []
 _args = list(sys.argv[1:])
 _i = 0
@@ -54,6 +61,16 @@ while _i < len(_args):
             sys.stderr.write("tuple-watcher: --offsets needs a tag value\n")
             sys.exit(2)
         offsets_tag = _args[_i]
+    elif a == "--max-wait":
+        _i += 1
+        if _i >= len(_args) or _args[_i].startswith("--"):
+            sys.stderr.write("tuple-watcher: --max-wait needs a seconds value\n")
+            sys.exit(2)
+        try:
+            max_wait = float(_args[_i])
+        except ValueError:
+            sys.stderr.write("tuple-watcher: --max-wait needs a numeric seconds value\n")
+            sys.exit(2)
     else:
         positional.append(a)
     _i += 1
@@ -224,6 +241,12 @@ if from_start:
     sys.exit(0)
 
 
+# --max-wait deadline (only with --exit-on-batch): after this much wall-clock
+# with no flush, exit anyway so a poll-loop caller regains its turn during a
+# silent stretch. Reset on each flushed batch isn't needed -- exit-on-batch exits
+# on flush, so this loop only runs once per invocation.
+wait_deadline = (time.time() + max_wait) if (exit_on_batch and max_wait is not None) else None
+
 while True:
     newdata = collect()
 
@@ -247,6 +270,13 @@ while True:
         buf = []
         have = False
         catchup = False
+
+    # Silence past --max-wait: hand control back with whatever we have (usually an
+    # empty batch -- flush() no-ops on an empty buffer). Lets a Monitor-less caller
+    # run its periodic work instead of blocking here until the next record.
+    if wait_deadline is not None and not have and now >= wait_deadline:
+        save_state(off)
+        sys.exit(0)
 
     time.sleep(1)
 


### PR DESCRIPTION
## Problem

Jack hit this: the Claude **sidekick** and both Claude **coaches** (pairing, drama-triangle) had exactly one live-follow path — catch up via `Bash --catchup`, then `Monitor` the continuous watcher. On **Bedrock, `Monitor` is disabled**, so live-follow had nowhere to go. The continuous watcher is an infinite loop; under plain `Bash` it blocks forever, the turn hangs, and nothing emits. That's the "Monitor wasn't working" symptom — the script was fine, the one path Claude was given depended on a tool that wasn't there.

Codex works because it has no `Monitor` and was already told to loop `--exit-on-batch` (run → batch → exit → repeat).

## Fix

Give each Claude harness the Codex-style fallback while keeping `Monitor` as the preferred path (it's superior — wakes on emit, lowest latency/cost — so we use it whenever it's available):

- **`Monitor` available** → subscribe to the continuous watcher, end turn, wait for records (unchanged).
- **No `Monitor`** (e.g. Bedrock) → loop `tuple-call-watcher.py --exit-on-batch` over `Bash`; never end the turn until `call_ended`.

### Watcher: new `--max-wait SECS`

The coaches' silence detection (quiet pair, silent driver, long grind, no goal) is driven by a fallback timer, because silence produces **no transcript records** to unblock `--exit-on-batch` — so a naive Bash-loop swap would block forever in a quiet room and silently disable half the coaching value.

`--max-wait SECS` makes `--exit-on-batch` return an empty batch after a silent stretch, handing the agent a turn to run its periodic checks. Each empty return is the same tick the Monitor path got from its fallback timer. The pairing coach uses it for real silence checks; the drama coach (purely line-based) just re-runs.

## Scope

| Trigger | Change |
|---|---|
| `sidekick-claude` | Monitor preferred + `--exit-on-batch` Bash fallback |
| `coach-pairing-claude` | same; empty `--max-wait 120` returns = silence ticks |
| `coach-drama-triangle-claude` | same; empty `--max-wait 300` returns are no-ops |
| `tuple-call-watcher.py` (×9) | new `--max-wait` flag, propagated byte-identically |
| READMEs | document the Bedrock fallback |

Untouched because already safe: **codex/opencode sidekicks** already loop `--exit-on-batch`; **call-summary** triggers run `--catchup` one-shot (no Monitor dependency, fire on `call-transcription-complete`).

## Validation

- `--max-wait` behavior tested empirically: times out to empty exit at the deadline, returns fast on a real batch, rejects non-numeric values (exit 2).
- All 9 watcher copies `py_compile` clean and remain byte-identical.
- All three reworked triggers pass their dry-run (`*_DRY_RUN=1`) and generate coherent prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)