### PR TITLE
Don't hardcode a Slack MCP path in the summary prompts

### DIFF
--- a/triggers/slack-call-summary-claude/README.md
+++ b/triggers/slack-call-summary-claude/README.md
@@ -9,7 +9,7 @@ Unlike the interactive `call-summary-claude` trigger, this one runs entirely in 
 - macOS
 - [Claude Code](https://claude.com/claude-code) installed so `claude` works in a new terminal
 - `python3` (the bundled watcher needs it; install with `xcode-select --install`)
-- The **claude.ai Slack connector** enabled in Claude Code. Verify it with `claude mcp list` — you should see `claude.ai Slack: Connected`. Connect it from [claude.ai](https://claude.ai) → Settings → Connectors, or run `/mcp` inside Claude Code.
+- A Slack MCP server or connector available to Claude Code. The **claude.ai Slack connector** works out of the box — verify it with `claude mcp list` (you should see `claude.ai Slack: Connected`); connect it from [claude.ai](https://claude.ai) → Settings → Connectors, or run `/mcp` inside Claude Code. Any other Slack MCP works too, as long as its tools are allowed in your Claude Code permission settings (or you add its `mcp__<server>` rule to the allowlist in the runner — allow rules can't glob server names).
 - Tuple transcription enabled for the call
 
 ## Installation

--- a/triggers/slack-call-summary-claude/call-transcription-complete
+++ b/triggers/slack-call-summary-claude/call-transcription-complete
@@ -136,7 +136,7 @@ If the transcript is empty or too sparse to summarize, the message becomes a one
 
 ## Deliver to Slack
 
-Send the composed message using your Slack MCP tools (mcp__claude_ai_Slack__slack_send_message; use slack_search_users / slack_search_channels first if you need to resolve the recipient).
+Send the composed message using your Slack tools — typically a `slack_send_message` tool from whatever Slack MCP server or connector you have. Use your Slack user/channel search tools first if you need to resolve the recipient.
 
 PROMPT
     if [ -n "${SLACK_RECIPIENT}" ]; then
@@ -166,6 +166,11 @@ if ! command -v python3 >/dev/null 2>&1; then
     exit 127
 fi
 
+# mcp__claude_ai_Slack pre-allows the claude.ai Slack connector so the send
+# works out of the box. Allow rules can't glob server names, but they merge
+# with your own Claude Code permission settings — any other Slack MCP works
+# as long as its tools are allowed there (or its mcp__<server> rule is added
+# below).
 exec claude -p \
     --allowed-tools "Read" "Write(slack-call-summary-claude-failed.md)" "Bash(./tuple-call-watcher.py:*)" "Bash(python3 tuple-call-watcher.py:*)" "mcp__claude_ai_Slack" \
     -- "$(cat "${SCRIPT_DIR}/slack-call-summary-claude-prompt.md")"

--- a/triggers/slack-call-summary-codex/README.md
+++ b/triggers/slack-call-summary-codex/README.md
@@ -9,7 +9,7 @@ Unlike the interactive `call-summary-codex` trigger, this one runs entirely in t
 - macOS
 - [Codex](https://developers.openai.com/codex/cli/) installed so `codex` works in a new terminal
 - `python3` (the bundled watcher needs it; install with `xcode-select --install`)
-- The Slack app connector enabled in Codex — sign in to the OpenAI-curated Slack plugin so `codex` has `slack_send_message` available
+- A Slack connector available to Codex with a `slack_send_message` tool. The OpenAI-curated Slack plugin works out of the box — enable it and sign in so `codex` has the Slack tools available.
 - Tuple transcription enabled for the call
 
 ## Installation

--- a/triggers/slack-call-summary-codex/call-transcription-complete
+++ b/triggers/slack-call-summary-codex/call-transcription-complete
@@ -136,7 +136,7 @@ If the transcript is empty or too sparse to summarize, the message becomes a one
 
 ## Deliver to Slack
 
-Send the composed message using your Slack connector tools (the slack_send_message tool from the Slack app connector; use slack_search_users / slack_search_channels first if you need to resolve the recipient).
+Send the composed message using your Slack tools — typically a `slack_send_message` tool from whatever Slack connector you have. Use your Slack user/channel search tools first if you need to resolve the recipient.
 
 PROMPT
     if [ -n "${SLACK_RECIPIENT}" ]; then


### PR DESCRIPTION
## Problem

The Slack Call Summary prompts named specific connector tool IDs (`mcp__claude_ai_Slack__slack_send_message` / "the OpenAI-curated Slack plugin"). For a customer with any other Slack MCP, that's an instruction pointing at a tool that doesn't exist.

## Solution

The prompts now just say to use "your Slack tools — typically a `slack_send_message` tool" and let the agent discover what it has. The claude runner keeps `mcp__claude_ai_Slack` in its allowlist purely as the out-of-the-box guarantee: allow rules can't glob server names (`mcp__*` is rejected), but they merge with the user's own Claude Code permission settings, so any Slack MCP the customer already allowed works unchanged. Both READMEs document this.

## Testing

- Live run with the genericized prompt: agent resolved its Slack tool and delivered the DM (verified in Slack).
- `bash -n` both scripts; repo trigger validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)