### PR TITLE
Encode participant/room names at the trigger sinks

### DIFF
--- a/triggers/git-coauthors/participant-joined
+++ b/triggers/git-coauthors/participant-joined
@@ -1,7 +1,28 @@
 #!/usr/bin/env ruby
 
-email = ENV.fetch("TUPLE_TRIGGER_EMAIL")
-name = ENV.fetch("TUPLE_TRIGGER_FULL_NAME")
+# Name and email come from another call participant, so they can hold arbitrary
+# bytes. A Co-Authored-By line is a single git trailer with no line continuation,
+# so anything that isn't a real name/email character is dropped here — otherwise
+# a newline in the name would inject extra trailers into ~/.gitmessage.
+# participant-left sanitizes identically so the add and remove match.
+
+# Letters in any script (with combining accents), digits, spaces, and the
+# punctuation names actually use. Everything else becomes a space, then runs of
+# space collapse.
+def name_safe(value)
+  value.gsub(/[^\p{L}\p{M}\p{N} .,'-]/, " ").squeeze(" ").strip
+end
+
+# The email sits inside <...>; drop whitespace and the brackets/quotes that would
+# let it escape, keep the @ . + _ - that emails legitimately use.
+def email_safe(value)
+  value.gsub(/[[:cntrl:]<>"'\s]/, "")
+end
+
+name = name_safe(ENV.fetch("TUPLE_TRIGGER_FULL_NAME"))
+email = email_safe(ENV.fetch("TUPLE_TRIGGER_EMAIL"))
+exit 0 if name.empty? || !email.include?("@")
+
 template_path = "#{Dir.home}/.gitmessage"
 line = "Co-Authored-By: #{name} <#{email}>"
 

--- a/triggers/git-coauthors/participant-left
+++ b/triggers/git-coauthors/participant-left
@@ -1,7 +1,17 @@
 #!/usr/bin/env ruby
 
-email = ENV.fetch("TUPLE_TRIGGER_EMAIL")
-name = ENV.fetch("TUPLE_TRIGGER_FULL_NAME")
+# Sanitize identically to participant-joined so the line we remove matches the
+# line that was written.
+def name_safe(value)
+  value.gsub(/[^\p{L}\p{M}\p{N} .,'-]/, " ").squeeze(" ").strip
+end
+
+def email_safe(value)
+  value.gsub(/[[:cntrl:]<>"'\s]/, "")
+end
+
+name = name_safe(ENV.fetch("TUPLE_TRIGGER_FULL_NAME"))
+email = email_safe(ENV.fetch("TUPLE_TRIGGER_EMAIL"))
 template_path = "#{Dir.home}/.gitmessage"
 
 if !File.exist?(template_path)

--- a/triggers/slack-room-notify/README.md
+++ b/triggers/slack-room-notify/README.md
@@ -2,6 +2,10 @@
 
 Notify a Slack #channel when you join a room.
 
+## Prerequisites
+
+- [`jq`](https://jqlang.github.io/jq/) (`brew install jq`) — used to build the JSON payload so participant and room names are safely encoded.
+
 ## Setup
 
 1. Create a Slack app at https://api.slack.com/apps. Click **Create New App → From scratch**, name it (e.g. "Tuple Room Notify"), and pick the workspace you want to post to.

--- a/triggers/slack-room-notify/room-joined
+++ b/triggers/slack-room-notify/room-joined
@@ -1,9 +1,25 @@
 #!/usr/bin/env bash
+set -uo pipefail
 
 # Replace with your generated URL from README instructions.
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxxxxxxxx/yyyyyyyyyy/zzzzzzzzzz
 
-if [ "$TUPLE_TRIGGER_IS_SELF" = "true" ]; then
-  MESSAGE="$TUPLE_TRIGGER_FULL_NAME joined the $TUPLE_TRIGGER_ROOM_NAME room"
-  curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$MESSAGE\"}" $SLACK_WEBHOOK_URL
+# Only announce our own joins.
+[ "${TUPLE_TRIGGER_IS_SELF:-false}" = "true" ] || exit 0
+
+# The name and room name come from other call participants and can contain any
+# character, including quotes and newlines. Build the JSON body with jq so those
+# values are encoded for the JSON context — never string-interpolate them into
+# the payload, or a quote in a name lets a participant forge arbitrary Slack
+# message text.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "slack-room-notify: jq is required (brew install jq)" >&2
+  exit 1
 fi
+
+payload="$(jq -n \
+  --arg name "${TUPLE_TRIGGER_FULL_NAME:-Someone}" \
+  --arg room "${TUPLE_TRIGGER_ROOM_NAME:-a}" \
+  '{text: ($name + " joined the " + $room + " room")}')"
+
+curl -fsS -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Why

Display names and room names come from other call participants and can contain arbitrary characters. Two triggers consumed those values without encoding them for their output context, so a malicious participant could break out of the sink. Reported via the Federacy bug bounty program.

- **`git-coauthors`** wrote `Co-Authored-By: <name> <email>` straight into `~/.gitmessage`. A trailer is a single line with no continuation, so a newline in the name injected extra trailers — silently added to every subsequent commit.
- **`slack-room-notify`** string-interpolated the name/room into a JSON webhook body (`{"text":"$MSG"}`). A `"` in a name let a participant forge arbitrary Slack message text and username.

The in-scope app and API aren't at fault here — they store the name as data and pass it to triggers over an env var that isn't shell-evaluated. The bug is at the sink, in these optional scripts, which is where the value crosses into a context (git-trailer grammar, JSON) that needs encoding.

## What

- **`git-coauthors/participant-joined` + `participant-left`**: whitelist the name to letters in any script (with combining accents), digits, spaces, and `. , ' -`; restrict the email to characters that can't escape the `<...>`. A positive whitelist is robust regardless of the sink and passes real names through untouched (`José Núñez-Größe`, `Siobhán O'Brien`, `田中 太郎`). Both scripts sanitize identically so the add and remove stay symmetric.
- **`slack-room-notify/room-joined`**: build the payload with `jq -n --arg` so the values are encoded for the JSON context — never interpolated. Also adds `set -uo pipefail`, a `jq` presence check, `curl -fsS`, and a quoted webhook URL. README notes the `jq` prerequisite.

## Testing

- Real accented / multi-script names survive intact.
- The reported newline PoC collapses to a single `Co-Authored-By:` line; `participant-left` removes exactly what `participant-joined` wrote; an all-symbol name / `@`-less email writes nothing.
- The Slack quote-injection payload is escaped (`\"`) and produces valid JSON with a single `text` key — spoof neutralized.
- `ruby -c` and `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)